### PR TITLE
Support Yarn aliases

### DIFF
--- a/fixtures/yarn-alias/index.js
+++ b/fixtures/yarn-alias/index.js
@@ -1,0 +1,2 @@
+require('some-pkg');
+require('some-pkg-with-alias');

--- a/fixtures/yarn-alias/node_modules/some-pkg-with-alias/index.js
+++ b/fixtures/yarn-alias/node_modules/some-pkg-with-alias/index.js
@@ -1,0 +1,5 @@
+const importLocal = require('import-local');
+
+if (importLocal(__filename)) {
+	console.log('local');
+}

--- a/fixtures/yarn-alias/node_modules/some-pkg-with-alias/package.json
+++ b/fixtures/yarn-alias/node_modules/some-pkg-with-alias/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "some-pkg",
+    "version": "1.0.0",
+    "main": "index.js"
+}

--- a/fixtures/yarn-alias/node_modules/some-pkg/index.js
+++ b/fixtures/yarn-alias/node_modules/some-pkg/index.js
@@ -1,0 +1,5 @@
+const importLocal = require('import-local');
+
+if (importLocal(__filename)) {
+	console.log('local');
+}

--- a/fixtures/yarn-alias/node_modules/some-pkg/package.json
+++ b/fixtures/yarn-alias/node_modules/some-pkg/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "some-pkg",
+    "version": "1.0.0",
+    "main": "index.js"
+}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const path = require('path');
+const findUp = require('find-up');
 const resolveCwd = require('resolve-cwd');
 const pkgDir = require('pkg-dir');
 
@@ -8,10 +9,7 @@ module.exports = filename => {
 	const relativePath = path.relative(globalDir, filename);
 	const pkg = require(path.join(globalDir, 'package.json'));
 	const localFile = resolveCwd.silent(path.join(pkg.name, relativePath));
+	const filenameIsLocal = findUp.sync(path.join(process.cwd(), 'node_modules'), {cwd: globalDir}) !== null;
 
-	// Use `path.relative()` to detect local package installation,
-	// because __filename's case is inconsistent on Windows
-	// Can use `===` when targeting Node.js 8
-	// See https://github.com/nodejs/node/issues/6624
-	return localFile && path.relative(localFile, filename) !== '' && require(localFile);
+	return localFile && !filenameIsLocal && require(localFile);
 };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"cli"
 	],
 	"dependencies": {
+		"find-up": "^3.0.0",
 		"pkg-dir": "^4.2.0",
 		"resolve-cwd": "^3.0.0"
 	},

--- a/test.js
+++ b/test.js
@@ -36,3 +36,19 @@ test('global', async t => {
 	t.is(stdout, '');
 });
 
+test('treats aliased package as local installation', async t => {
+	await cpy(
+		['package.json', 'index.js'],
+		path.join(__dirname, 'fixtures/yarn-alias/node_modules/import-local'),
+		{parents: true}
+	);
+	const {stdout} = await execa(
+		'node',
+		[path.join(__dirname, 'fixtures/yarn-alias/index.js')],
+		{
+			preferLocal: false,
+			cwd: path.join(__dirname, 'fixtures/yarn-alias')
+		}
+	);
+	t.is(stdout, '');
+});


### PR DESCRIPTION
Fixes #1.

The current implementation noops if it finds a "local" copy of the file at the exact same path as the "global" one (i.e. when the file actually was installed locally). This diff maintains that behavior, but also noops if the filename is installed anywhere under the local `node_modules`. Now calling `importLocal` on a file that is aliased inside local `node_modules` is guaranteed to do nothing.