### PR TITLE
Fix regression with preferring local install when invoked through global CLI

### DIFF
--- a/fixtures/prefer-local/cli.js
+++ b/fixtures/prefer-local/cli.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+'use strict';
+const importLocal = require('../..');
+
+if (importLocal(__filename)) {
+	console.log('local');
+}

--- a/fixtures/prefer-local/nested/node_modules/some-pkg/package.json
+++ b/fixtures/prefer-local/nested/node_modules/some-pkg/package.json
@@ -1,0 +1,3 @@
+{
+	"name": "some-pkg"
+}

--- a/fixtures/prefer-local/package.json
+++ b/fixtures/prefer-local/package.json
@@ -1,0 +1,3 @@
+{
+	"name": "some-pkg"
+}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 const path = require('path');
-const findUp = require('find-up');
 const resolveCwd = require('resolve-cwd');
 const pkgDir = require('pkg-dir');
 
@@ -9,7 +8,8 @@ module.exports = filename => {
 	const relativePath = path.relative(globalDir, filename);
 	const pkg = require(path.join(globalDir, 'package.json'));
 	const localFile = resolveCwd.silent(path.join(pkg.name, relativePath));
-	const filenameIsLocal = findUp.sync(path.join(process.cwd(), 'node_modules'), {cwd: globalDir, type: 'directory'}) !== undefined;
+	const localNodeModules = path.join(process.cwd(), 'node_modules');
+	const filenameInLocalNodeModules = !path.relative(localNodeModules, filename).startsWith('..');
 
-	return localFile && !filenameIsLocal && require(localFile);
+	return !filenameInLocalNodeModules && localFile && require(localFile);
 };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
 		"cli"
 	],
 	"dependencies": {
-		"find-up": "^4.1.0",
 		"pkg-dir": "^4.2.0",
 		"resolve-cwd": "^3.0.0"
 	},

--- a/test.js
+++ b/test.js
@@ -28,6 +28,26 @@ test('local', async t => {
 	await del(path.join(__dirname, 'fixtures/local/node_modules'));
 });
 
+test('invoking global prefers local', async t => {
+	await cpy(
+		['package.json', 'index.js'],
+		path.join(__dirname, 'fixtures/prefer-local/node_modules/import-local'),
+		{parents: true}
+	);
+
+	const {stdout} = await execa(
+		'node',
+		[path.join(__dirname, 'fixtures/prefer-local/cli.js')],
+		{
+			preferLocal: false,
+			cwd: path.join(__dirname, 'fixtures/prefer-local/nested')
+		}
+	);
+	t.is(stdout, 'local');
+
+	await del(path.join(__dirname, 'fixtures/prefer-local/node_modules'));
+});
+
 test('global', async t => {
 	const {stdout} = await execa('import-local-fixture', {
 		preferLocal: false,


### PR DESCRIPTION
This fixes the issue described in avajs/ava#2168.

The problem was that I was using `findUp.sync` to detect whether the local `node_modules` is a parent directory of `globalDir`. I expected that function to only return true when the path in the first argument was found while traversing up the directory tree, but because we provide an absolute path, it actually always returned true.

This wasn't caught in CI because there's no test where we invoke a global CLI, but want to resolve to a version in the local node_modules, so I've added a regression test.

@sindresorhus @novemberborn: In addition to these tests, I've verified that the "prefers local version of ava" test passes in ava when linked to this branch.