### PR TITLE
Fix regression for projects using Lerna

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: node_js
-os:
-  - linux
-  - osx
-  - windows
 node_js:
   - '12'
   - '10'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: node_js
+os:
+  - linux
+  - osx
+  - windows
 node_js:
   - '12'
   - '10'

--- a/fixtures/5-nested/foo/index.js
+++ b/fixtures/5-nested/foo/index.js
@@ -1,0 +1,1 @@
+require('sample');

--- a/fixtures/5-nested/node_modules/sample/index.js
+++ b/fixtures/5-nested/node_modules/sample/index.js
@@ -1,0 +1,7 @@
+const importLocal = require('import-local');
+
+if (importLocal(__filename)) {
+	console.log('Using local version of this package');
+} else {
+    console.log('Called');
+}

--- a/fixtures/5-nested/node_modules/sample/package.json
+++ b/fixtures/5-nested/node_modules/sample/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "sample"
+}

--- a/index.js
+++ b/index.js
@@ -11,5 +11,9 @@ module.exports = filename => {
 	const localNodeModules = path.join(process.cwd(), 'node_modules');
 	const filenameInLocalNodeModules = !path.relative(localNodeModules, filename).startsWith('..');
 
-	return !filenameInLocalNodeModules && localFile && require(localFile);
+	// Use `path.relative()` to detect local package installation,
+	// because __filename's case is inconsistent on Windows
+	// Can use `===` when targeting Node.js 8
+	// See https://github.com/nodejs/node/issues/6624
+	return !filenameInLocalNodeModules && localFile && path.relative(localFile, filename) !== '' && require(localFile);
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"resolve-cwd": "^3.0.0"
 	},
 	"devDependencies": {
-		"ava": "^2.1.0",
+		"ava": "2.1.0",
 		"cpy": "^7.0.1",
 		"del": "^4.1.1",
 		"execa": "^2.0.1",

--- a/test.js
+++ b/test.js
@@ -72,3 +72,22 @@ test('treats aliased package as local installation', async t => {
 	);
 	t.is(stdout, '');
 });
+
+// https://github.com/sindresorhus/import-local/pull/5
+test('import from node_modules in a parent directory', async t => {
+	await cpy(
+		['package.json', 'index.js', 'fixtures/cli.js'],
+		path.join(__dirname, 'fixtures/5-nested/node_modules/import-local'),
+		{parents: true}
+	);
+	const {stdout} = await execa(
+		'node',
+		['index.js'],
+		{
+			preferLocal: false,
+			cwd: path.join(__dirname, 'fixtures/5-nested/foo')
+		}
+	);
+	t.is(stdout, 'Called');
+	await del(path.join(__dirname, 'fixtures/5-nested/node_modules/import-local'));
+});


### PR DESCRIPTION
I wrote this PR because [ava@2.2.0](https://github.com/avajs/ava/releases/tag/v2.2.0) exits with 0 without running a test in my project uses [Lerna](https://github.com/lerna/lerna).

This is [the sample code in the README](https://github.com/sindresorhus/import-local/blob/3b6d85bea895f8ef3acad55e7fb7d06a4d77a2aa/readme.md#usage):

https://github.com/sindresorhus/import-local/blob/3b6d85bea895f8ef3acad55e7fb7d06a4d77a2aa/readme.md#L18-L24

And this is the [current (v3.0.1) index.js](https://github.com/sindresorhus/import-local/blob/3b6d85bea895f8ef3acad55e7fb7d06a4d77a2aa/index.js):

https://github.com/sindresorhus/import-local/blob/3b6d85bea895f8ef3acad55e7fb7d06a4d77a2aa/index.js#L6-L15

If `filename === localFile`,  the function returns truthy value now (v3.0.1), and the process never executes the else-statements. AVA CLI uses the same code hence it causes false negatives in CI.

Here's a reproduction of this issue:

- https://repl.it/@KeiIto/import-local-200 (v2.0.0)
- https://repl.it/@KeiIto/import-local-301 (v3.0.1)

![v2](https://user-images.githubusercontent.com/7359068/60990610-c9037100-a383-11e9-8fc7-003404e4840d.png)

![v3](https://user-images.githubusercontent.com/7359068/60990618-cef95200-a383-11e9-9f71-ba45d69c39a7.png)

I reverted [a condition and comments from v2.0.0](https://github.com/sindresorhus/import-local/blob/ca0a08fe9b9072a73294a875e93970ac0634f452/index.js#L16).