### PR TITLE
fix: Fixed the Windows path problem

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,12 @@ module.exports = filename => {
 	const pkg = require(path.join(globalDir, 'package.json'));
 	const localFile = resolveCwd.silent(path.join(pkg.name, relativePath));
 	const localNodeModules = path.join(process.cwd(), 'node_modules');
-	const filenameInLocalNodeModules = !path.relative(localNodeModules, filename).startsWith('..');
+	const fileInLocalPath = path.relative(localNodeModules, filename);
+	const filenameInLocalNodeModules = fileInLocalPath.startsWith('..') || (os.type() === 'Windows_NT' && path.isAbsolute(fileInLocalPath));
 
 	// Use `path.relative()` to detect local package installation,
 	// because __filename's case is inconsistent on Windows
 	// Can use `===` when targeting Node.js 8
 	// See https://github.com/nodejs/node/issues/6624
-	return !filenameInLocalNodeModules && localFile && path.relative(localFile, filename) !== '' && require(localFile);
+	return filenameInLocalNodeModules && localFile && path.relative(localFile, filename) !== '' && require(localFile);
 };

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const path = require('path');
 const resolveCwd = require('resolve-cwd');
 const pkgDir = require('pkg-dir');
+const os = require('os')
 
 module.exports = filename => {
 	const globalDir = pkgDir.sync(path.dirname(filename));


### PR DESCRIPTION
In Windows, `path.relative(localNodeModules, filename).startsWith('..')` May cause errors in the judgment,
for example:

```js
  path.relative(
    'E:\\sunshine-cli\\packages\\core\\lib\\node_modules',
    'C:\\Users\\37564\\AppData\\Roaming\\npm\\node_modules\\lerna\\cli.js'
  )
```