### PR TITLE
fix: Windows different partition path problem

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = filename => {
 	const pkg = require(path.join(globalDir, 'package.json'));
 	const localFile = resolveCwd.silent(path.join(pkg.name, relativePath));
 	const localNodeModules = path.join(process.cwd(), 'node_modules');
-	const filenameInLocalNodeModules = !path.relative(localNodeModules, filename).startsWith('..') && localNodeModules.charAt(0) === filename.charAt(0);
+	const filenameInLocalNodeModules = !path.relative(localNodeModules, filename).startsWith('..')  && localNodeModules.charCodeAt(0) === filename.charCodeAt(0);
 
 	// Use `path.relative()` to detect local package installation,
 	// because __filename's case is inconsistent on Windows

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = filename => {
 	const pkg = require(path.join(globalDir, 'package.json'));
 	const localFile = resolveCwd.silent(path.join(pkg.name, relativePath));
 	const localNodeModules = path.join(process.cwd(), 'node_modules');
-	const filenameInLocalNodeModules = !path.relative(localNodeModules, filename).startsWith('..');
+	const filenameInLocalNodeModules = !path.relative(localNodeModules, filename).startsWith('..') && localNodeModules.charAt(0) === filename.charAt(0);
 
 	// Use `path.relative()` to detect local package installation,
 	// because __filename's case is inconsistent on Windows


### PR DESCRIPTION
description：In windows, if localNodeModules and filename is in different partition, path.relative will return the value of filename. Then filenameInLocalNodeModules will be true. 
solved:  In this case, the first char of localNodeModules and filename will be different. Adding a condition change filenameInLocalNodeModules to false.
In unix, the new condition will always be true, don't break the logic before.