### PR TITLE
Fix handling of different partitions on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = filename => {
 	const pkg = require(path.join(globalDir, 'package.json'));
 	const localFile = resolveCwd.silent(path.join(pkg.name, relativePath));
 	const localNodeModules = path.join(process.cwd(), 'node_modules');
-	const filenameInLocalNodeModules = !path.relative(localNodeModules, filename).startsWith('..');
+	const filenameInLocalNodeModules = !path.relative(localNodeModules, filename).startsWith('..') && localNodeModules.charCodeAt(0) === filename.charCodeAt(0);
 
 	// Use `path.relative()` to detect local package installation,
 	// because __filename's case is inconsistent on Windows

--- a/index.js
+++ b/index.js
@@ -9,11 +9,10 @@ module.exports = filename => {
 	const pkg = require(path.join(globalDir, 'package.json'));
 	const localFile = resolveCwd.silent(path.join(pkg.name, relativePath));
 	const localNodeModules = path.join(process.cwd(), 'node_modules');
-	// In windows system, if localNodeModules and filename are in different partitions,
-	// path.relative() returns the value of filename and filenameInLocalNodeModules gets true.
-	// filenameInLocalNodeModules should be false.
-	// Adding a condition that compares the root of two variables will solve this problem.
-	const filenameInLocalNodeModules = !path.relative(localNodeModules, filename).startsWith('..') && path.parse(localNodeModules).root === path.parse(filename).root;
+
+	const filenameInLocalNodeModules = !path.relative(localNodeModules, filename).startsWith('..')
+		// On Windows, if `localNodeModules` and `filename` are on different partitions, `path.relative()` returns the value of `filename`, resulting in `filenameInLocalNodeModules` incorrectly becoming `true`.
+		&& path.parse(localNodeModules).root === path.parse(filename).root;
 
 	// Use `path.relative()` to detect local package installation,
 	// because __filename's case is inconsistent on Windows

--- a/index.js
+++ b/index.js
@@ -9,7 +9,11 @@ module.exports = filename => {
 	const pkg = require(path.join(globalDir, 'package.json'));
 	const localFile = resolveCwd.silent(path.join(pkg.name, relativePath));
 	const localNodeModules = path.join(process.cwd(), 'node_modules');
-	const filenameInLocalNodeModules = !path.relative(localNodeModules, filename).startsWith('..') && localNodeModules.charCodeAt(0) === filename.charCodeAt(0);
+	// In windows system, if localNodeModules and filename are in different partitions,
+	// path.relative() returns the value of filename and filenameInLocalNodeModules gets true.
+	// filenameInLocalNodeModules should be false.
+	// Adding a condition that compares the root of two variables will solve this problem.
+	const filenameInLocalNodeModules = !path.relative(localNodeModules, filename).startsWith('..') && path.parse(localNodeModules).root === path.parse(filename).root;
 
 	// Use `path.relative()` to detect local package installation,
 	// because __filename's case is inconsistent on Windows


### PR DESCRIPTION
description: In windows, if localNodeModules and filename is in different partition, path.relative will return the value of filename. then filenameInLocalNodeModules will be true. It is fault.
solved: In this case, the first char of localNodeModules and filename will be different. adding a condition make filenameInLocalNodeModules
In unix, the new condition will always be true, don't break the logic before.