### PR TITLE
Add type declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,1 @@
-declare function importLocal(__filename: string): boolean | undefined | unknown;
-export = importLocal;
+export default function importLocal(__filename: string): boolean | undefined | unknown;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 /**
-Let a globally installed package use a locally installed version of itself if available
+Let a globally installed package use a locally installed version of itself if available.
 
-@param __filename - The name of the package.
+@param filePath - The absolute file path to the main file of the package.
 
 @example
-```js
+```
 import importLocal from 'import-local';
 
 if (importLocal(import.meta.url)) {
@@ -14,4 +14,4 @@ if (importLocal(import.meta.url)) {
 }
 ```
 */
-export default function importLocal(__filename: string): boolean | undefined | unknown;
+export default function importLocal(filePath: string): boolean | undefined | unknown;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+declare function importLocal(__filename: string): boolean | undefined | unknown;
+export = importLocal;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,17 @@
+/**
+Let a globally installed package use a locally installed version of itself if available
+
+@param __filename - The name of the package.
+
+@example
+```js
+import importLocal from 'import-local';
+
+if (importLocal(import.meta.url)) {
+	console.log('Using local version of this package');
+} else {
+	// Code for both global and local version here…
+}
+```
+*/
 export default function importLocal(__filename: string): boolean | undefined | unknown;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,4 @@
+import { expectType } from 'tsd';
+import importLocal from './index.js';
+
+expectType<boolean | undefined | unknown>(importLocal("import-local"))

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,0 @@
-import { expectType } from 'tsd';
-import importLocal from './index.js';
-
-expectType<boolean | undefined | unknown>(importLocal("import-local"))

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava && tsd"
 	},
 	"files": [
 		"index.js",
+		"index.d.ts",
 		"fixtures/cli.js"
 	],
 	"keywords": [
@@ -42,6 +43,7 @@
 		"cpy": "^7.0.1",
 		"del": "^4.1.1",
 		"execa": "^2.0.1",
+		"tsd": "^0.31.1",
 		"xo": "^0.24.0"
 	},
 	"xo": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava && tsd"
+		"test": "xo && ava"
 	},
 	"files": [
 		"index.js",
@@ -43,7 +43,6 @@
 		"cpy": "^7.0.1",
 		"del": "^4.1.1",
 		"execa": "^2.0.1",
-		"tsd": "^0.31.1",
 		"xo": "^0.24.0"
 	},
 	"xo": {


### PR DESCRIPTION
### Motivation
The current type declaration on DefinitelyTyped of this package does not accurately reflect the function's return type. See [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/import-local/index.d.ts).

### Why
The most recent version of this function (as well as the oldest ones) is not designed to return just the boolean type. In the `return` [line](https://github.com/sindresorhus/import-local/blob/b45c5a6b68488da41b69ae6a8d2ef5edadb3de85/index.js#L23), it can either return: 
- `false` if the first or third operand is false.
- `undefined` if the second operand is undefined.
- whatever is exported from `require()` of the last operand, given all the previous values are truthy.